### PR TITLE
Implement sign-in page

### DIFF
--- a/wlm-ui/package.json
+++ b/wlm-ui/package.json
@@ -1,7 +1,8 @@
 {
   "name": "wlm-ui",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
+  "proxy": "http://127.0.0.1:8000",
   "dependencies": {
     "@reduxjs/toolkit": "^2.3.0",
     "@testing-library/jest-dom": "^5.14.1",

--- a/wlm-ui/package.json
+++ b/wlm-ui/package.json
@@ -13,6 +13,7 @@
     "eslint": "^9.14.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/wlm-ui/package.json
+++ b/wlm-ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^2.3.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -10,12 +11,15 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "axios": "^1.7.7",
     "eslint": "^9.14.0",
     "eslint-config-react-app": "^7.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-redux": "^9.1.2",
     "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
+    "redux": "^5.0.1",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/wlm-ui/package.json
+++ b/wlm-ui/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "eslint": "^9.14.0",
+    "eslint-config-react-app": "^7.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/wlm-ui/src/App.tsx
+++ b/wlm-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 

--- a/wlm-ui/src/App.tsx
+++ b/wlm-ui/src/App.tsx
@@ -1,19 +1,31 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 import './App.css';
 import InitPage from './InitPage/InitPage';
 import MainPage from './MainPage/MainPage';
+import { selectUser } from './store/slices/user/user';
 
 function App() {
+  const userState = useSelector(selectUser);
+
   return (
     <div className='App'>
-      <BrowserRouter>
-        <Routes>
-          <Route path='/init' element={<InitPage />} />
-          <Route path='/' element={<MainPage />} />
-          <Route path='*' element={<h1>Not Found</h1>} />
-        </Routes>
-      </BrowserRouter>
+      {userState.user === null ? (
+        <BrowserRouter>
+          <Routes>
+            <Route path='/init' element={<InitPage />} />
+            <Route path='*' element={<Navigate to='/init' replace />} />
+          </Routes>
+        </BrowserRouter>
+      ) : (
+        <BrowserRouter>
+          <Routes>
+            <Route path='/' element={<MainPage />} />
+            <Route path='*' element={<Navigate to='/' replace />} />
+          </Routes>
+        </BrowserRouter>
+      )}
     </div>
   );
 }

--- a/wlm-ui/src/App.tsx
+++ b/wlm-ui/src/App.tsx
@@ -1,24 +1,19 @@
-import React from 'react';
-import logo from './logo.svg';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
 import './App.css';
+import InitPage from './InitPage/InitPage';
+import MainPage from './MainPage/MainPage';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div className='App'>
+      <BrowserRouter>
+        <Routes>
+          <Route path='/init' element={<InitPage />} />
+          <Route path='/' element={<MainPage />} />
+          <Route path='*' element={<h1>Not Found</h1>} />
+        </Routes>
+      </BrowserRouter>
     </div>
   );
 }

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
 import { AppDispatch } from '../store';
@@ -9,14 +10,17 @@ const InitPage = () => {
     const [password, setPassword] = useState<string>('');
 
     const dispatch = useDispatch<AppDispatch>();
+    const navigate = useNavigate();
 
     const onClickSignin = async () => {
         if (username !== '' && password !== '') {
             const data = { username: username, password: password };
             dispatch(signin(data))
                 .unwrap()
-                .then(() => {})
-                .catch(() => {})
+                .then(() => {
+                    navigate('/');
+                })
+                .catch(() => {});
         }
     };
 

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -3,6 +3,9 @@ import { useState } from "react";
 const InitPage = () => {
     const [username, setUsername] = useState<string>('')
     const [password, setPassword] = useState<string>('')
+
+    const onClickSignin = async () => {};
+
     return (
         <div>
             <input
@@ -17,6 +20,11 @@ const InitPage = () => {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
             />
+            <button
+                onClick={onClickSignin}
+            >
+                Sign in
+            </button>
         </div>
     );
 };

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 const InitPage = () => {
-    const [username, setUsername] = useState<string>('')
-    const [password, setPassword] = useState<string>('')
+    const [username, setUsername] = useState<string>('');
+    const [password, setPassword] = useState<string>('');
 
     const onClickSignin = async () => {};
 

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 const InitPage = () => {
     const [username, setUsername] = useState<string>('')
+    const [password, setPassword] = useState<string>('')
     return (
         <div>
             <input
@@ -9,6 +10,12 @@ const InitPage = () => {
                 placeholder="username"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
+            />
+            <input
+                type="password"
+                placeholder="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
             />
         </div>
     );

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,22 +1,26 @@
-import { useState } from "react";
+import { useState } from 'react';
 
 const InitPage = () => {
     const [username, setUsername] = useState<string>('');
     const [password, setPassword] = useState<string>('');
 
-    const onClickSignin = async () => {};
+    const onClickSignin = async () => {
+        if (username !== '' && password !== '') {
+            const data = { username: username, password: password };
+        }
+    };
 
     return (
         <div>
             <input
-                type="text"
-                placeholder="username"
+                type='text'
+                placeholder='username'
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
             />
             <input
-                type="password"
-                placeholder="password"
+                type='password'
+                placeholder='password'
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
             />

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,12 +1,22 @@
 import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { AppDispatch } from '../store';
+import { signin } from '../store/slices/user/user';
 
 const InitPage = () => {
     const [username, setUsername] = useState<string>('');
     const [password, setPassword] = useState<string>('');
 
+    const dispatch = useDispatch<AppDispatch>();
+
     const onClickSignin = async () => {
         if (username !== '' && password !== '') {
             const data = { username: username, password: password };
+            dispatch(signin(data))
+                .unwrap()
+                .then(() => {})
+                .catch(() => {})
         }
     };
 

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
 import { AppDispatch } from '../store';
@@ -10,17 +9,11 @@ const InitPage = () => {
     const [password, setPassword] = useState<string>('');
 
     const dispatch = useDispatch<AppDispatch>();
-    const navigate = useNavigate();
 
     const onClickSignin = async () => {
         if (username !== '' && password !== '') {
             const data = { username: username, password: password };
             dispatch(signin(data))
-                .unwrap()
-                .then(() => {
-                    navigate('/');
-                })
-                .catch(() => {});
         }
     };
 

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { AppDispatch } from '../store';

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,0 +1,9 @@
+const InitPage = () => {
+    return (
+        <div>
+            Init
+        </div>
+    );
+};
+
+export default InitPage;

--- a/wlm-ui/src/InitPage/InitPage.tsx
+++ b/wlm-ui/src/InitPage/InitPage.tsx
@@ -1,7 +1,15 @@
+import { useState } from "react";
+
 const InitPage = () => {
+    const [username, setUsername] = useState<string>('')
     return (
         <div>
-            Init
+            <input
+                type="text"
+                placeholder="username"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+            />
         </div>
     );
 };

--- a/wlm-ui/src/MainPage/MainPage.tsx
+++ b/wlm-ui/src/MainPage/MainPage.tsx
@@ -1,0 +1,9 @@
+const MainPage = () => {
+    return (
+        <div>
+            Main
+        </div>
+    );
+};
+
+export default MainPage;

--- a/wlm-ui/src/MainPage/MainPage.tsx
+++ b/wlm-ui/src/MainPage/MainPage.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const MainPage = () => {
     return (
         <div>

--- a/wlm-ui/src/index.tsx
+++ b/wlm-ui/src/index.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { store } from './store';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}><App /></Provider>
   </React.StrictMode>
 );
 

--- a/wlm-ui/src/store/index.ts
+++ b/wlm-ui/src/store/index.ts
@@ -1,0 +1,8 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+export const store = configureStore({
+    reducer: {},
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/wlm-ui/src/store/index.ts
+++ b/wlm-ui/src/store/index.ts
@@ -1,7 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import userReducer from "./slices/user/user";
+
 export const store = configureStore({
-    reducer: {},
+    reducer: {
+        user: userReducer,
+    },
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -1,3 +1,5 @@
+import { createSlice } from '@reduxjs/toolkit';
+
 export interface TeamType {
     id: number;
     name: string;
@@ -15,3 +17,9 @@ export interface UserInfo {
 };
 
 const initialState: UserInfo = { user: null };
+
+export const userSlice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {},
+});

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -31,7 +31,7 @@ export const signin = createAsyncThunk(
     async (user: Pick<UserType, 'username' | 'password'>) => {
         const response = await axios.post('/user/signin/', user);
         return response.data;
-    }
+    },
 );
 
 export const userSlice = createSlice({
@@ -44,7 +44,7 @@ export const userSlice = createSlice({
                 state.user = action.payload.user;
                 localStorage.setItem('user.user', JSON.stringify(state.user));
             })
-    }
+    },
 });
 
 export const userActions = userSlice.actions;

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -1,6 +1,8 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
 
+import { RootState } from '../..';
+
 export interface TeamType {
     id: number;
     name: string;
@@ -38,3 +40,8 @@ export const userSlice = createSlice({
             })
     }
 });
+
+export const userActions = userSlice.actions;
+export const selectUser = (state: RootState) => state.user;
+
+export default userSlice.reducer;

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -3,6 +3,9 @@ import axios from 'axios';
 
 import { RootState } from '../..';
 
+axios.defaults.xsrfCookieName = 'csrftoken';
+axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+
 export interface TeamType {
     id: number;
     name: string;

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -1,0 +1,11 @@
+export interface TeamType {
+    id: number;
+    name: string;
+};
+
+export interface UserType {
+    id: number,
+    username: string,
+    password: string,
+    team: TeamType;
+};

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -31,4 +31,10 @@ export const userSlice = createSlice({
     name: 'user',
     initialState,
     reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(signin.fulfilled, (state, action) => {
+                state.user = action.payload.user;
+            })
+    }
 });

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -9,3 +9,7 @@ export interface UserType {
     password: string,
     team: TeamType;
 };
+
+export interface UserInfo {
+    user: UserType | null;
+};

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -1,4 +1,5 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
 
 export interface TeamType {
     id: number;
@@ -17,6 +18,14 @@ export interface UserInfo {
 };
 
 const initialState: UserInfo = { user: null };
+
+export const signin = createAsyncThunk(
+    'user/signin',
+    async (user: Pick<UserType, 'username' | 'password'>) => {
+        const response = await axios.post('/user/signin/', user);
+        return response.data;
+    }
+);
 
 export const userSlice = createSlice({
     name: 'user',

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -13,3 +13,5 @@ export interface UserType {
 export interface UserInfo {
     user: UserType | null;
 };
+
+const initialState: UserInfo = { user: null };

--- a/wlm-ui/src/store/slices/user/user.ts
+++ b/wlm-ui/src/store/slices/user/user.ts
@@ -22,7 +22,9 @@ export interface UserInfo {
     user: UserType | null;
 };
 
-const initialState: UserInfo = { user: null };
+const initialState: UserInfo = {
+    user: JSON.parse(localStorage.getItem('user.user') || 'null'),
+};
 
 export const signin = createAsyncThunk(
     'user/signin',
@@ -40,6 +42,7 @@ export const userSlice = createSlice({
         builder
             .addCase(signin.fulfilled, (state, action) => {
                 state.user = action.payload.user;
+                localStorage.setItem('user.user', JSON.stringify(state.user));
             })
     }
 });

--- a/wlm-ui/yarn.lock
+++ b/wlm-ui/yarn.lock
@@ -1690,6 +1690,11 @@
     schema-utils "^4.2.0"
     source-map "^0.7.3"
 
+"@remix-run/router@1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.21.0.tgz#c65ae4262bdcfe415dbd4f64ec87676e4a56e2b5"
+  integrity sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -8143,6 +8148,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@^6.28.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.28.0.tgz#f73ebb3490e59ac9f299377062ad1d10a9f579e6"
+  integrity sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==
+  dependencies:
+    "@remix-run/router" "1.21.0"
+    react-router "6.28.0"
+
+react-router@6.28.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.0.tgz#29247c86d7ba901d7e5a13aa79a96723c3e59d0d"
+  integrity sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==
+  dependencies:
+    "@remix-run/router" "1.21.0"
 
 react-scripts@5.0.1:
   version "5.0.1"

--- a/wlm-ui/yarn.lock
+++ b/wlm-ui/yarn.lock
@@ -1690,6 +1690,16 @@
     schema-utils "^4.2.0"
     source-map "^0.7.3"
 
+"@reduxjs/toolkit@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.3.0.tgz#d00134634d6c1678e8563ac50026e429e3b64420"
+  integrity sha512-WC7Yd6cNGfHx8zf+iu+Q1UPTfEcXhQ+ATi7CV1hlrSAaQBdlPzg7Ww/wJHNQem7qG9rxmWoFCDCPubSvFObGzA==
+  dependencies:
+    immer "^10.0.3"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.1.0"
+
 "@remix-run/router@1.21.0":
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.21.0.tgz#c65ae4262bdcfe415dbd4f64ec87676e4a56e2b5"
@@ -2278,6 +2288,11 @@
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/ws@^8.5.5":
   version "8.5.13"
@@ -2966,6 +2981,15 @@ axe-core@^4.10.0:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
+
+axios@^1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -4964,7 +4988,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -5007,6 +5031,15 @@ form-data@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.2.tgz#83ad9ced7c03feaad97e293d6f6091011e1659c8"
   integrity sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
+  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -5486,6 +5519,11 @@ ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+immer@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
 
 immer@^9.0.7:
   version "9.0.21"
@@ -8013,6 +8051,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -8143,6 +8186,14 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-redux@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.1.2.tgz#deba38c64c3403e9abd0c3fbeab69ffd9d8a7e4b"
+  integrity sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==
+  dependencies:
+    "@types/use-sync-external-store" "^0.0.3"
+    use-sync-external-store "^1.0.0"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -8277,6 +8328,16 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-thunk@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
+  integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
+
+redux@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
+  integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
+
 reflect.getprototypeof@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz#3ab04c32a8390b770712b7a8633972702d278859"
@@ -8388,6 +8449,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+reselect@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -9570,6 +9636,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This resolves #3.

I implemented as below.
- Two pages; `InitPage` (sign-in) and `MainPage` (still emtpy).
- Sign-in UI, e.g., `username` input.
- Navigate to `MainPage` when sign-in succeeds.
- Protect pages based on sign-in status.
- Store user state using `redux` and `localStorage`.

`InitPage` is as shown below.

![image](https://github.com/user-attachments/assets/80eb5790-f608-488e-b57b-97654e915bbd)
