### PR TITLE
Request for calibrating WLM

### DIFF
--- a/wlm-ui/src/MainPage/MainPage.tsx
+++ b/wlm-ui/src/MainPage/MainPage.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { AppDispatch } from '../store';
 import { signout } from '../store/slices/user/user';
+import { calibrate } from '../store/slices/calibration/calibration';
 import ChannelList from './Channel/ChannelList';
 
 const MainPage = () => {
@@ -12,8 +13,13 @@ const MainPage = () => {
         dispatch(signout());
     };
 
+    const onClickCalibration = async () => {
+        dispatch(calibrate());
+    };
+
     return (
         <div>
+            <button onClick={onClickCalibration}>Calibration</button>
             <button onClick={onClickSignout}>Sign out</button>
             <ChannelList />
         </div>

--- a/wlm-ui/src/MainPage/MainPage.tsx
+++ b/wlm-ui/src/MainPage/MainPage.tsx
@@ -19,7 +19,7 @@ const MainPage = () => {
 
     return (
         <div>
-            <button onClick={onClickCalibration}>Calibration</button>
+            <button onClick={onClickCalibration}>Calibrate</button>
             <button onClick={onClickSignout}>Sign out</button>
             <ChannelList />
         </div>

--- a/wlm-ui/src/store/slices/calibration/calibration.ts
+++ b/wlm-ui/src/store/slices/calibration/calibration.ts
@@ -1,0 +1,9 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const calibrate = createAsyncThunk(
+    'calibration',
+    async () => {
+        await axios.post('/calibration/');
+    },
+);


### PR DESCRIPTION
This resolves #12.

I misunderstand that the calibration button is disabled when the WLM is running.
In that situation, the request is just ignored on server-side.

I will handle rejected requests later, so please ignore it in this PR.