### PR TITLE
Request to acquire or release lock, and show lock status in real-time

### DIFF
--- a/wlm-ui/src/MainPage/Channel/Channel.scss
+++ b/wlm-ui/src/MainPage/Channel/Channel.scss
@@ -31,4 +31,9 @@
     grid-template-columns: auto 60px auto auto;
     grid-template-rows: auto auto;
     gap: 10px;
+
+    &.disabled {
+        pointer-events: none;
+        opacity: 0.5;
+    }
 }

--- a/wlm-ui/src/MainPage/Channel/Channel.scss
+++ b/wlm-ui/src/MainPage/Channel/Channel.scss
@@ -12,6 +12,13 @@
     justify-content: space-between;
 }
 
+.channel-lock-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 10px;
+}
+
 .channel-attr-viewer-container {
     display: flex;
     flex-direction: row;

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -21,6 +21,7 @@ interface IProps extends ChannelInfo {
 const Channel = (props: IProps) => {
     const [isInUseButtonEnabled, setIsInUseButtonEnabled] = useState<boolean>(true);
     const [shouldUpdatePlot, setShouldUpdatePlot] = useState<boolean>(true);
+    const [isLockButtonEnabled, setIsLockButtonEnabled] = useState<boolean>(true);
     const [exposure, setExposure] = useState<number>(0);
     const [period, setPeriod] = useState<number>(0);
     const measurementsRef = useRef(props.measurements);
@@ -117,6 +118,10 @@ const Channel = (props: IProps) => {
         setIsInUseButtonEnabled(true);
     }, [props.inUse]);
 
+    useEffect(() => {
+        setIsLockButtonEnabled(true);
+    }, [props.hasLock]);
+
     return (
         <div className='channel-item'>
             <div className='channel-title'>
@@ -206,7 +211,15 @@ const Channel = (props: IProps) => {
             <div className='channel-lock-container'>
                 <span>{props.lock.locked ? `Locked by ${props.lock.owner}` : 'Open'}</span>
                 <button
-                    onClick={props.hasLock ? props.onClickReleaseLock : props.onClickTryLock }
+                    disabled={!isLockButtonEnabled}
+                    onClick={() => {
+                        setIsLockButtonEnabled(false);
+                        if (props.hasLock) {
+                            props.onClickReleaseLock();
+                        } else {
+                            props.onClickTryLock();
+                        }
+                    }}
                 >
                     {props.hasLock ? 'Release' : 'Acquire'}
                 </button>

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -22,6 +22,7 @@ const Channel = (props: IProps) => {
     const [isInUseButtonEnabled, setIsInUseButtonEnabled] = useState<boolean>(true);
     const [shouldUpdatePlot, setShouldUpdatePlot] = useState<boolean>(true);
     const [isLockButtonEnabled, setIsLockButtonEnabled] = useState<boolean>(true);
+    const canUpdateSettings = !props.lock.locked || (props.hasLock && isLockButtonEnabled);
     const [exposure, setExposure] = useState<number>(0);
     const [period, setPeriod] = useState<number>(0);
     const measurementsRef = useRef(props.measurements);
@@ -234,7 +235,7 @@ const Channel = (props: IProps) => {
                     {props.setting.period} s
                 </span>
             </div>
-            <div className={'channel-attr-editor-container'}>
+            <div className={`channel-attr-editor-container ${!canUpdateSettings && 'disabled'}`}>
                 <b style={{ textAlign: 'left' }}>Exp. time</b>
                 <input
                     type='number'

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -188,6 +188,10 @@ const Channel = (props: IProps) => {
                     )}
                 </h1>
             </div>
+            <div className='channel-lock-container'>
+                <span>{props.lock.locked ? `Locked by ${props.lock.owner}` : 'Open'}</span>
+                <button>{props.hasLock ? 'Release' : 'Acquire'}</button>
+            </div>
             <div className='channel-attr-viewer-container'>
                 <b>Exp. time</b>
                 <span style={{ width: '60px', textAlign: 'right' }}>

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -14,6 +14,8 @@ interface IProps extends ChannelInfo {
     onClickSetInUse: (inUse: boolean) => void;
     onClickSetExposure: (exposure: number) => void;
     onClickSetPeriod: (period: number) => void;
+    onClickTryLock: () => void;
+    onClickReleaseLock: () => void;
 };
 
 const Channel = (props: IProps) => {
@@ -203,7 +205,11 @@ const Channel = (props: IProps) => {
             </div>
             <div className='channel-lock-container'>
                 <span>{props.lock.locked ? `Locked by ${props.lock.owner}` : 'Open'}</span>
-                <button>{props.hasLock ? 'Release' : 'Acquire'}</button>
+                <button
+                    onClick={props.hasLock ? props.onClickReleaseLock : props.onClickTryLock }
+                >
+                    {props.hasLock ? 'Release' : 'Acquire'}
+                </button>
             </div>
             <div className='channel-attr-viewer-container'>
                 <b>Exp. time</b>

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -4,7 +4,7 @@ import { Line } from '@nivo/line';
 
 import { AppDispatch } from '../../store';
 import {
-    channelListActions, SettingType, MeasurementType, ChannelInfo
+    channelListActions, SettingType, MeasurementType, LockType, ChannelInfo
 } from '../../store/slices/channel/channel';
 import './Channel.scss';
 
@@ -51,6 +51,19 @@ const Channel = (props: IProps) => {
             const data = JSON.parse(event.data) as MeasurementType | MeasurementType[];
             dispatch(channelListActions.fetchMeasurements(
                 { channel: channel, measurements: data }));
+        };
+
+        return () => socket.close();
+    }, [dispatch, props.channel.channel]);
+
+    useEffect(() => {
+        const channel = props.channel.channel;
+        const socket = new WebSocket(`${process.env.REACT_APP_WEBSOCKET_URL}/lock/${channel}/`);
+
+        socket.onmessage = event => {
+            const data = JSON.parse(event.data) as LockType;
+            dispatch(channelListActions.fetchLock(
+                { channel: channel, lock: data }));
         };
 
         return () => socket.close();

--- a/wlm-ui/src/MainPage/Channel/ChannelList.tsx
+++ b/wlm-ui/src/MainPage/Channel/ChannelList.tsx
@@ -32,6 +32,14 @@ const ChannelList = () => {
         dispatch(postPeriod({ channel: channel, period: period }));
     };
 
+    const onClickTryLock = (channel: number) => {
+
+    };
+
+    const onClickReleaseLock = (channel: number) => {
+
+    };
+
     return (
         <div>
             <button onClick={onClickRefreshChannelList}>Refresh</button>
@@ -46,6 +54,8 @@ const ChannelList = () => {
                                 onClickSetExposure(info.channel.channel, exposure)}
                             onClickSetPeriod={(period: number) =>
                                 onClickSetPeriod(info.channel.channel, period)}
+                            onClickTryLock={() => onClickTryLock(info.channel.channel)}
+                            onClickReleaseLock={() => onClickReleaseLock(info.channel.channel)}
                         />
                     </article>
                 ))}

--- a/wlm-ui/src/MainPage/Channel/ChannelList.tsx
+++ b/wlm-ui/src/MainPage/Channel/ChannelList.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { AppDispatch } from '../../store';
 import {
-    fetchList, postInUse, postExposure, postPeriod, selectChannelList,
+    fetchList, postInUse, postExposure, postPeriod, tryLock, releaseLock, selectChannelList,
 } from '../../store/slices/channel/channel';
 import Channel from './Channel';
 import './ChannelList.scss';
@@ -33,11 +33,11 @@ const ChannelList = () => {
     };
 
     const onClickTryLock = (channel: number) => {
-
+        dispatch(tryLock({ channel: channel }));
     };
 
     const onClickReleaseLock = (channel: number) => {
-
+        dispatch(releaseLock({ channel: channel }));
     };
 
     return (

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -115,6 +115,13 @@ export const channelListSlice = createSlice({
                 info.measurements.push(measurements);
             }
         },
+        fetchLock: (
+            state, action: PayloadAction<Pick<ChannelType, 'channel'> & { lock: LockType }>
+        ) => {
+            const { channel, lock } = action.payload;
+            const info = getChannelInfoWithException(state, channel);
+            info.lock = lock;
+        },
         removeOldMeasurements: (state, action: PayloadAction<Pick<ChannelType, 'channel'>>) => {
             const info = getChannelInfoWithException(state, action.payload.channel);
             const cutoffTime = new Date(Date.now() - 10 * 60 * 1000);

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -86,6 +86,24 @@ export const postPeriod = createAsyncThunk(
     },
 );
 
+export const tryLock = createAsyncThunk(
+    'channel/tryLock',
+    async (payload: Pick<ChannelType, 'channel'>) => {
+        const { channel } = payload;
+        await axios.post(`/lock/${channel}/try/`);
+        return { channel: channel };
+    },
+);
+
+export const releaseLock = createAsyncThunk(
+    'channel/releaseLock',
+    async (payload: Pick<ChannelType, 'channel'>) => {
+        const { channel } = payload;
+        await axios.put(`/lock/${channel}/release/`);
+        return { channel: channel };
+    },
+);
+
 export const channelListSlice = createSlice({
     name: 'channelList',
     initialState,
@@ -151,6 +169,14 @@ export const channelListSlice = createSlice({
             .addCase(postInUse.fulfilled, (state, action) => {
                 const info = getChannelInfoWithException(state, action.payload.channel);
                 info.inUse = action.payload.inUse;
+            })
+            .addCase(tryLock.fulfilled, (state, action) => {
+                const info = getChannelInfoWithException(state, action.payload.channel);
+                info.hasLock = true;
+            })
+            .addCase(releaseLock.fulfilled, (state, action) => {
+                const info = getChannelInfoWithException(state, action.payload.channel);
+                info.hasLock = false;
             })
     },
 });

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -19,11 +19,18 @@ export interface MeasurementType {
     measuredAt: string;
 };
 
+export interface LockType {
+    locked: boolean;
+    owner: string | null;
+};
+
 export interface ChannelInfo {
     channel: ChannelType;
     inUse: boolean;
     setting: SettingType;
     measurements: MeasurementType[];
+    hasLock: boolean;
+    lock: LockType;
 };
 
 export interface ChannelListInfo {
@@ -49,7 +56,8 @@ const getChannelInfoWithException = (state: ChannelListInfo, channel: number) =>
 export const fetchList = createAsyncThunk(
     'channel/fetch',
     async () => {
-        const response = await axios.get<(ChannelType & Pick<ChannelInfo, 'inUse'>)[]>('/channel/');
+        const response = await axios.get<
+            (ChannelType & Pick<ChannelInfo, 'inUse' | 'hasLock'>)[]>('/channel/');
         return response.data;
     },
 );
@@ -128,6 +136,8 @@ export const channelListSlice = createSlice({
                         inUse: ch.inUse,
                         setting: info?.setting ?? { exposure: 0, period: 0 },
                         measurements: info?.measurements ?? [],
+                        hasLock: ch.hasLock,
+                        lock: info?.lock ?? { locked: false, owner: null },
                     } as ChannelInfo;
                 }).sort((a, b) => a.channel.channel - b.channel.channel);
             })


### PR DESCRIPTION
This resolves #13.

I implemented three features regarding locks.

- Try to acquire a lock
- Release the lock
- Show the lock status in real time

There is a unresolved issue that the lock button gets disabled forever when the user tries to acquire a lock while an other user already has the lock.
To enable the lock button, the user should refresh the page.
I'll handle this in a later issue, so please keep as it is.

An example UI is below.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/0f57cf57-b70f-4ff0-90cc-a581c939c51e" />
