### PR TITLE
Shot measurement status and measurer list

### DIFF
--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -4,7 +4,7 @@ import { Line } from '@nivo/line';
 
 import { AppDispatch } from '../../store';
 import {
-    channelListActions, SettingType, MeasurementType, LockType, ChannelInfo
+    channelListActions, OperationType, SettingType, MeasurementType, LockType, ChannelInfo
 } from '../../store/slices/channel/channel';
 import './Channel.scss';
 
@@ -41,6 +41,19 @@ const Channel = (props: IProps) => {
             const data = JSON.parse(event.data) as Partial<SettingType>;
             dispatch(channelListActions.fetchSetting(
                 { channel: channel, ...data }));
+        };
+
+        return () => socket.close();
+    }, [dispatch, props.channel.channel]);
+
+    useEffect(() => {
+        const channel = props.channel.channel;
+        const socket = new WebSocket(`${process.env.REACT_APP_WEBSOCKET_URL}/operation/${channel}/`);
+
+        socket.onmessage = event => {
+            const data = JSON.parse(event.data) as OperationType;
+            dispatch(channelListActions.fetchOperation(
+                { channel: channel, operation: data }));
         };
 
         return () => socket.close();

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -141,6 +141,7 @@ const Channel = (props: IProps) => {
             <div className='channel-title'>
                 <b>CH {props.channel.channel}</b>
                 <span>{props.channel.name}</span>
+                <span>{props.operation.on ? 'ON' : 'OFF'}</span>
                 <button
                     disabled={!isInUseButtonEnabled}
                     onClick={() => {
@@ -152,6 +153,9 @@ const Channel = (props: IProps) => {
                     {props.inUse ? 'In use' : 'Use'}
                 </button>
             </div>
+            <span style={{ textAlign: 'left' }}>
+                Requesters: {props.operation.requesters.join(', ')}
+            </span>
             <div style={{ display: props.inUse ? 'block' : 'none' }}>
                 <button onClick={() => setShouldUpdatePlot(!shouldUpdatePlot)}>
                     {shouldUpdatePlot ? 'Stop' : 'Start'}

--- a/wlm-ui/src/MainPage/Channel/Channel.tsx
+++ b/wlm-ui/src/MainPage/Channel/Channel.tsx
@@ -154,7 +154,7 @@ const Channel = (props: IProps) => {
                 </button>
             </div>
             <span style={{ textAlign: 'left' }}>
-                Requesters: {props.operation.requesters.join(', ')}
+                Users: {props.operation.requesters.join(', ')}
             </span>
             <div style={{ display: props.inUse ? 'block' : 'none' }}>
                 <button onClick={() => setShouldUpdatePlot(!shouldUpdatePlot)}>

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -8,6 +8,11 @@ export interface ChannelType {
     name: string;
 };
 
+export interface OperationType {
+    on: boolean;
+    requesters: string[];
+};
+
 export interface SettingType {
     exposure: number;
     period: number;
@@ -27,6 +32,7 @@ export interface LockType {
 export interface ChannelInfo {
     channel: ChannelType;
     inUse: boolean;
+    operation: OperationType;
     setting: SettingType;
     measurements: MeasurementType[];
     hasLock: boolean;
@@ -159,6 +165,7 @@ export const channelListSlice = createSlice({
                     return {
                         channel: { channel: ch.channel, name: ch.name },
                         inUse: ch.inUse,
+                        operation: info?.operation ?? { on: false, requesters: [] },
                         setting: info?.setting ?? { exposure: 0, period: 0 },
                         measurements: info?.measurements ?? [],
                         hasLock: ch.hasLock,

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -114,6 +114,14 @@ export const channelListSlice = createSlice({
     name: 'channel',
     initialState,
     reducers: {
+        fetchOperation: (
+            state,
+            action: PayloadAction<Pick<ChannelType, 'channel'> & { operation: OperationType }>
+        ) => {
+            const { channel, operation } = action.payload;
+            const info = getChannelInfoWithException(state, channel);
+            info.operation = operation;
+        },
         fetchSetting: (
             state, action: PayloadAction<Pick<ChannelType, 'channel'> & Partial<SettingType>>
         ) => {


### PR DESCRIPTION
This resolves #25.

An example UI is as follows.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/cb730f47-1db8-4a95-b3a2-ee211accf5b7" />
