### PR TITLE
Disable setting access for users without a lock

### DIFF
--- a/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
+++ b/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
@@ -57,7 +57,7 @@ const Channel = (props: Props) => {
     const [timeSliderRange, setTimeSliderRange] = useState<number[]>([]);
     const [timeSliderMarks, setTimeSliderMarks] = useState<{ value: number, label: string }[]>([]);
     const [isSettingOpen, setIsSettingOpen] = useState<boolean>(false);
-    const canUpdateSettings = !props.lock.locked || (props.hasLock && isLockButtonEnabled);
+    const canUpdateSettings = props.hasLock && isLockButtonEnabled;
     const exposureId = `channel-${props.channel.channel}-exposure`;
     const periodId = `channel-${props.channel.channel}-period`;
     const measurementsRef = useRef(props.measurements);
@@ -388,7 +388,12 @@ const Channel = (props: Props) => {
                         >
                             <Switch
                                 checked={props.hasLock}
-                                disabled={!canUpdateSettings}
+                                disabled={
+                                    !(
+                                        isLockButtonEnabled &&
+                                        (!props.lock.locked || props.hasLock)
+                                    )
+                                }
                                 size='small'
                                 onChange={() => {
                                     setIsLockButtonEnabled(false);


### PR DESCRIPTION
This resolves #43.

Now a user without a lock cannot access the setting even if the channel is open.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/092f5f22-4f94-4994-bbc6-0de25bf978a6" />
