### PR TITLE
Add `hasDacInfo` field to `ChannelType` and implement conditional rendering for DAC panels

### DIFF
--- a/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
+++ b/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
@@ -160,6 +160,7 @@ const Channel = (props: Props) => {
             <ChannelHeader
                 channel={channel}
                 channelName={props.channel.name}
+                hasDacInfo={props.channel.hasDacInfo}
                 operation={props.operation}
                 lock={props.lock}
                 pid={props.pid}

--- a/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
+++ b/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
@@ -56,7 +56,8 @@ const Channel = (props: Props) => {
     const dispatch = useDispatch<AppDispatch>();
     const channel = props.channel.channel;
 
-    const { areAllSocketsConnected, sendDacVoltage } = useChannelSockets(channel, props.hasLock);
+    const { areAllSocketsConnected, sendDacVoltage } = useChannelSockets(
+        channel, props.hasLock, props.channel.hasDacInfo);
 
     const {
         latestMeasurementText,

--- a/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
+++ b/wlm-ui/src/pages/MainPage/components/Channel/Channel.tsx
@@ -204,7 +204,7 @@ const Channel = (props: Props) => {
             ) : (
                 <Skeleton variant='rounded' height={50} />
             )}
-            {areAllSocketsConnected ? (
+            {props.channel.hasDacInfo && areAllSocketsConnected ? (
                 <DacOutputPanel
                     isOpen={isDacOutputOpen}
                     onToggle={() => setIsDacOutputOpen(!isDacOutputOpen)}
@@ -214,9 +214,9 @@ const Channel = (props: Props) => {
                     sendVoltage={sendDacVoltage}
                 />
             ) : (
-                <Skeleton variant='rounded' height={50} />
+                props.channel.hasDacInfo && <Skeleton variant='rounded' height={50} />
             )}
-            {areAllSocketsConnected ? (
+            {props.channel.hasDacInfo && areAllSocketsConnected ? (
                 <PidSettingPanel
                     isOpen={isPidSettingOpen}
                     onToggle={() => setIsPidSettingOpen(!isPidSettingOpen)}
@@ -226,7 +226,7 @@ const Channel = (props: Props) => {
                     onPidSettingChange={handlePidSettingChange}
                 />
             ) : (
-                <Skeleton variant='rounded' height={50} />
+                props.channel.hasDacInfo && <Skeleton variant='rounded' height={50} />
             )}
             <Stack
                 direction='row'

--- a/wlm-ui/src/pages/MainPage/components/Channel/components/ChannelHeader.tsx
+++ b/wlm-ui/src/pages/MainPage/components/Channel/components/ChannelHeader.tsx
@@ -13,6 +13,7 @@ import { OperationType, LockType, PidType } from '../../../../../store/slices/ch
 type Props = {
     channel: number;
     channelName: string;
+    hasDacInfo: boolean;
     operation: OperationType;
     lock: LockType;
     pid: PidType;
@@ -33,6 +34,7 @@ type Props = {
 const ChannelHeader = ({
     channel,
     channelName,
+    hasDacInfo,
     operation,
     lock,
     pid,
@@ -160,52 +162,54 @@ const ChannelHeader = ({
                             />
                         </Grid>
                     </Grid>
-                    <Grid
-                        container
-                        size={12}
-                        sx={{ display: 'flex', alignItems: 'center' }}
-                    >
+                    {hasDacInfo && (
                         <Grid
-                            size={5.5}
-                            sx={{ display: 'flex', justifyContent: 'flex-start' }}
+                            container
+                            size={12}
+                            sx={{ display: 'flex', alignItems: 'center' }}
                         >
-                            <Typography variant='overline'>
-                                {pid.on ? 'PID' : 'MANUAL'}
-                            </Typography>
+                            <Grid
+                                size={5.5}
+                                sx={{ display: 'flex', justifyContent: 'flex-start' }}
+                            >
+                                <Typography variant='overline'>
+                                    {pid.on ? 'PID' : 'MANUAL'}
+                                </Typography>
+                            </Grid>
+                            <Grid
+                                size={2}
+                                sx={{ display: 'flex', justifyContent: 'center' }}
+                            >
+                                <Box
+                                    sx={{
+                                        width: '12px',
+                                        height: '12px',
+                                        backgroundColor: pid.on ? 'green' : 'grey',
+                                        borderRadius: '50%',
+                                    }}
+                                />
+                            </Grid>
+                            <Grid
+                                size={4.5}
+                                sx={{ display: 'flex', justifyContent: 'flex-end' }}
+                            >
+                                <Switch
+                                    checked={hasPid}
+                                    disabled={
+                                        !(
+                                            !isPidRequestPending &&
+                                            inUse &&
+                                            hasLock
+                                        )
+                                    }
+                                    size='small'
+                                    onChange={() => {
+                                        onPidToggle(hasPid);
+                                    }}
+                                />
+                            </Grid>
                         </Grid>
-                        <Grid
-                            size={2}
-                            sx={{ display: 'flex', justifyContent: 'center' }}
-                        >
-                            <Box
-                                sx={{
-                                    width: '12px',
-                                    height: '12px',
-                                    backgroundColor: pid.on ? 'green' : 'grey',
-                                    borderRadius: '50%',
-                                }}
-                            />
-                        </Grid>
-                        <Grid
-                            size={4.5}
-                            sx={{ display: 'flex', justifyContent: 'flex-end' }}
-                        >
-                            <Switch
-                                checked={hasPid}
-                                disabled={
-                                    !(
-                                        !isPidRequestPending &&
-                                        inUse &&
-                                        hasLock
-                                    )
-                                }
-                                size='small'
-                                onChange={() => {
-                                    onPidToggle(hasPid);
-                                }}
-                            />
-                        </Grid>
-                    </Grid>
+                    )}
                 </Grid>
             ) : (
                 <Skeleton variant='rounded' width={140} height={75} />

--- a/wlm-ui/src/pages/MainPage/components/Channel/hooks/useChannelSockets.ts
+++ b/wlm-ui/src/pages/MainPage/components/Channel/hooks/useChannelSockets.ts
@@ -12,7 +12,7 @@ import {
     LockType,
 } from '../../../../../store/slices/channel/channel';
 
-export const useChannelSockets = (channel: number, hasLock: boolean) => {
+export const useChannelSockets = (channel: number, hasLock: boolean, hasDacInfo: boolean) => {
     const dispatch = useDispatch<AppDispatch>();
     const [isOperationSocketConnected, setIsOperationSocketConnected] = useState<boolean>(false);
     const [isLockSocketConnected, setIsLockSocketConnected] = useState<boolean>(false);
@@ -27,11 +27,13 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
     const areAllSocketsConnected =
         isOperationSocketConnected &&
         isLockSocketConnected &&
-        isPidOperationSocketConnected &&
         isMeasurementSocketConnected &&
         isSettingSocketConnected &&
-        isDacOutputSocketConnected &&
-        isPidSettingSocketConnected;
+        (!hasDacInfo || (
+            isPidOperationSocketConnected &&
+            isDacOutputSocketConnected &&
+            isPidSettingSocketConnected
+        ));
 
     useEffect(() => {
         const socket = new WebSocket(`/ws/operation/${channel}/`);
@@ -72,6 +74,11 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
     }, [dispatch, channel]);
 
     useEffect(() => {
+        if (!hasDacInfo) {
+            setIsPidOperationSocketConnected(false);
+            return;
+        }
+
         const socket = new WebSocket(`/ws/pid_operation/${channel}/`);
 
         socket.onopen = () => {
@@ -88,7 +95,7 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
         };
 
         return () => socket.close();
-    }, [dispatch, channel]);
+    }, [dispatch, channel, hasDacInfo]);
 
     useEffect(() => {
         const socket = new WebSocket(`/ws/measurement/${channel}/`);
@@ -129,6 +136,11 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
     }, [dispatch, channel]);
 
     useEffect(() => {
+        if (!hasDacInfo) {
+            setIsDacOutputSocketConnected(false);
+            return;
+        }
+
         const socket = new WebSocket(`/ws/pid_setting/dac_output/${channel}/`);
 
         socket.onopen = () => {
@@ -145,9 +157,14 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
         };
 
         return () => socket.close();
-    }, [dispatch, channel]);
+    }, [dispatch, channel, hasDacInfo]);
 
     useEffect(() => {
+        if (!hasDacInfo) {
+            setIsPidSettingSocketConnected(false);
+            return;
+        }
+
         const socket = new WebSocket(`/ws/pid_setting/${channel}/`);
 
         socket.onopen = () => {
@@ -164,10 +181,10 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
         };
 
         return () => socket.close();
-    }, [dispatch, channel]);
+    }, [dispatch, channel, hasDacInfo]);
 
     useEffect(() => {
-        if (!hasLock) {
+        if (!hasLock || !hasDacInfo) {
             if (dacControlSocketRef.current) {
                 dacControlSocketRef.current.close();
                 dacControlSocketRef.current = null;
@@ -195,7 +212,7 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
             socket.close();
             dacControlSocketRef.current = null;
         };
-    }, [channel, hasLock]);
+    }, [channel, hasLock, hasDacInfo]);
 
     const sendDacVoltage = (voltage: number) => {
         if (dacControlSocketRef.current?.readyState === WebSocket.OPEN) {

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -6,6 +6,7 @@ import { RootState } from '../..';
 export interface ChannelType {
     channel: number;
     name: string;
+    hasDacInfo: boolean;
 };
 
 export interface OperationType {
@@ -242,7 +243,7 @@ export const channelListSlice = createSlice({
                 state.channels = action.payload.map((ch) => {
                     const info = getChannelInfo(state, ch.channel);
                     return {
-                        channel: { channel: ch.channel, name: ch.name },
+                        channel: { channel: ch.channel, name: ch.name, hasDacInfo: ch.hasDacInfo },
                         inUse: ch.inUse,
                         operation: info?.operation ?? { on: false, requesters: [] },
                         setting: info?.setting ?? { exposure: 0, period: 0 },


### PR DESCRIPTION
This resolves #58.

For example, channel 9 has no DAC so the corresponding components aren't shown.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/9f7ce40e-b1d1-41ac-8f95-b8333a729922" />
