### PR TITLE
PID Status Support

### DIFF
--- a/wlm-ui/src/pages/MainPage/components/Channel/components/ChannelHeader.tsx
+++ b/wlm-ui/src/pages/MainPage/components/Channel/components/ChannelHeader.tsx
@@ -181,7 +181,9 @@ const ChannelHeader = ({
                                 sx={{
                                     width: '12px',
                                     height: '12px',
-                                    backgroundColor: pid.on ? 'green' : 'grey',
+                                    backgroundColor: 
+                                        !pid.on ? 'grey' :
+                                        pid.status ? 'green' : 'red',
                                     borderRadius: '50%',
                                 }}
                             />

--- a/wlm-ui/src/pages/MainPage/components/Channel/hooks/useChannelSockets.ts
+++ b/wlm-ui/src/pages/MainPage/components/Channel/hooks/useChannelSockets.ts
@@ -79,7 +79,7 @@ export const useChannelSockets = (channel: number, hasLock: boolean) => {
         };
 
         socket.onmessage = event => {
-            const data = JSON.parse(event.data) as Pick<PidType, 'on'>;
+            const data = JSON.parse(event.data) as Pick<PidType, 'on' | 'status'>;
             dispatch(channelListActions.fetchPidOperation({ channel: channel, ...data }));
         };
 

--- a/wlm-ui/src/store/slices/channel/channel.ts
+++ b/wlm-ui/src/store/slices/channel/channel.ts
@@ -31,6 +31,7 @@ export interface PidSettingType {
 
 export interface PidType {
     on: boolean;
+    status: boolean;
     dacOutput: DacOutputType;
     setting: PidSettingType;
 };
@@ -172,11 +173,12 @@ export const channelListSlice = createSlice({
         },
         fetchPidOperation: (
             state,
-            action: PayloadAction<Pick<ChannelType, 'channel'> & Pick<PidType, 'on'>>
+            action: PayloadAction<Pick<ChannelType, 'channel'> & Pick<PidType, 'on' | 'status'>>
         ) => {
-            const { channel, on } = action.payload;
+            const { channel, on, status } = action.payload;
             const info = getChannelInfoWithException(state, channel);
             info.pid.on = on;
+            info.pid.status = status;
         },
         fetchPidSetting: (
             state,
@@ -248,7 +250,8 @@ export const channelListSlice = createSlice({
                         setting: info?.setting ?? { exposure: 0, period: 0 },
                         hasPid: ch.hasPid,
                         pid: info?.pid ?? { 
-                            on: false, 
+                            on: false,
+                            status: false,
                             dacOutput: { voltage: 0 },
                             setting: {
                                 targetFrequency: 0,


### PR DESCRIPTION
This resolves #65.

For example, when a measured frequency is too far from the target frequency, the PID status is shown as red:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/21ba0a37-9114-4752-9d17-ae45e9b97d7c" />
